### PR TITLE
modify 19-coroutine/coroaverager3:grouper

### DIFF
--- a/19-coroutine/coroaverager3.py
+++ b/19-coroutine/coroaverager3.py
@@ -63,8 +63,10 @@ def averager():  # <1>
 
 # the delegating generator
 def grouper(results, key):  # <5>
-    while True:  # <6>
-        results[key] = yield from averager()  # <7>
+    results[key] = yield from averager()
+    yield
+    # while True:  # <6>
+    #     results[key] = yield from averager()  # <7>
 
 
 # the client code, a.k.a. the caller


### PR DESCRIPTION
In annotations <6>："Each iteration in thisloop creates a new instance of averager; **_each is a generator object operating as a coroutine._**" and <7>:"Whenever grouper is sent a value, it’s piped ．．．, the value it returns is bound to results[key]. **_The while loop then proceeds to create another averager instance to consume more values_**."
This two annotations and `while True` loop will misguide noob readers(like me) to a certain degree.
It would be better to replace `while True` with `yield`.
Please info me if I get something wrong.
Thanks for your coding. 