### PR TITLE
Use fixture instead of yield_fixture

### DIFF
--- a/23-dyn-attr-prop/oscon/test_schedule_v1.py
+++ b/23-dyn-attr-prop/oscon/test_schedule_v1.py
@@ -3,7 +3,7 @@ import pytest
 import schedule_v1 as schedule
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def records():
     yield schedule.load(schedule.JSON_PATH)
 

--- a/23-dyn-attr-prop/oscon/test_schedule_v2.py
+++ b/23-dyn-attr-prop/oscon/test_schedule_v2.py
@@ -2,7 +2,7 @@ import pytest
 
 import schedule_v2 as schedule
 
-@pytest.yield_fixture
+@pytest.fixture
 def records():
     yield schedule.load(schedule.JSON_PATH)
 

--- a/23-dyn-attr-prop/oscon/test_schedule_v3.py
+++ b/23-dyn-attr-prop/oscon/test_schedule_v3.py
@@ -2,7 +2,7 @@ import pytest
 
 import schedule_v3 as schedule
 
-@pytest.yield_fixture
+@pytest.fixture
 def records():
     yield schedule.load(schedule.JSON_PATH)
 

--- a/23-dyn-attr-prop/oscon/test_schedule_v4.py
+++ b/23-dyn-attr-prop/oscon/test_schedule_v4.py
@@ -2,7 +2,7 @@ import pytest
 
 import schedule_v4 as schedule
 
-@pytest.yield_fixture
+@pytest.fixture
 def records():
     yield schedule.load(schedule.JSON_PATH)
 

--- a/23-dyn-attr-prop/oscon/test_schedule_v5.py
+++ b/23-dyn-attr-prop/oscon/test_schedule_v5.py
@@ -2,7 +2,7 @@ import pytest
 
 import schedule_v5 as schedule
 
-@pytest.yield_fixture
+@pytest.fixture
 def records():
     yield schedule.load(schedule.JSON_PATH)
 


### PR DESCRIPTION
The old @pytest.yield_fixture causes
a deprecation warning:
Use @pytest.fixture instead; they are the same.
    def records():