### PR TITLE
Fix Tuple type hint

### DIFF
--- a/21-async/domains/asyncio/blogdom.py
+++ b/21-async/domains/asyncio/blogdom.py
@@ -2,11 +2,12 @@
 import asyncio
 import socket
 from keyword import kwlist
+from typing import Tuple
 
 MAX_KEYWORD_LEN = 4  # <1>
 
 
-async def probe(domain: str) -> tuple[str, bool]:  # <2>
+async def probe(domain: str) -> Tuple[str, bool]:  # <2>
     loop = asyncio.get_running_loop()  # <3>
     try:
         await loop.getaddrinfo(domain, None)  # <4>


### PR DESCRIPTION
The type hint for the probe async coroutine definition was 'tuple' instead of 'Tuple'. This caused python 3.8.10 to fail to compile the code.