### PR TITLE
More consistent way to get suit value and suits length 

### DIFF
--- a/01-data-model/data-model.ipynb
+++ b/01-data-model/data-model.ipynb
@@ -443,11 +443,10 @@
     }
    ],
    "source": [
-    "suit_values = dict(spades=3, hearts=2, diamonds=1, clubs=0)\n",
-    "\n",
     "def spades_high(card):\n",
     "    rank_value = FrenchDeck.ranks.index(card.rank)\n",
-    "    return rank_value * len(suit_values) + suit_values[card.suit]\n",
+    "    suit_value = FrenchDeck.suits.index(card.suit)\n",
+    "    return rank_value * len(FrenchDeck.suits) + suit_value\n",
     "\n",
     "for card in sorted(deck, key=spades_high):\n",
     "    print(card)"


### PR DESCRIPTION
Change from using different way to get suit value than `rank_value`

```py
suit_values = dict(spades=3, hearts=2, diamonds=1, clubs=0)

def spades_high(card):
    rank_value = FrenchDeck.ranks.index(card.rank)
    return rank_value * len(suit_values) + suit_values[card.suit]
```
To be more consistent. Also we can get suit_values from existing class variable `FrenchDeck.suits`.

```py
def spades_high(card):
    rank_value = FrenchDeck.ranks.index(card.rank)
    suit_value = FrenchDeck.suits.index(card.suit)
    return rank_value * len(FrenchDeck.suits) + suit_value
```