### PR TITLE
Fix chapter number to 2ed edition

### DIFF
--- a/06-obj-ref/README.rst
+++ b/06-obj-ref/README.rst
@@ -1,4 +1,4 @@
-Sample code for Chapter 8 - "Object references, mutability and recycling"
+Sample code for Chapter 6 - "Object references, mutability and recycling"
 
 From the book "Fluent Python" by Luciano Ramalho (O'Reilly, 2015)
 http://shop.oreilly.com/product/0636920032519.do


### PR DESCRIPTION
On 2ed the chapter "Object references, mutability and recycling" from 8 to 6
This commit fixes the readme with the new chapter number