### PR TITLE
Fix `error` variable not being reset when failure in a coroutine call in flags2_asyncio.py

### DIFF
--- a/20-executors/getflags/flags2_asyncio.py
+++ b/20-executors/getflags/flags2_asyncio.py
@@ -79,6 +79,8 @@ async def supervisor(cc_list: list[str],
                 error = exc  # <10>
             except KeyboardInterrupt:
                 break
+            else:
+                error = None
 
             if error:
                 status = DownloadStatus.ERROR  # <11>


### PR DESCRIPTION
In the `asyncio` example in ` flags2_asyncio.py` there is a bug when a call to a coroutine in the loop fails and the next one has success, the `error` variable doesn't get reset and it still thinks it got an error, and updates the `counter[status]` with the wrong value