### PR TITLE
mysum.py - incorrect import of type Iterable from collections package

### DIFF
--- a/15-more-types/mysum.py
+++ b/15-more-types/mysum.py
@@ -1,7 +1,6 @@
 import functools
 import operator
-from collections.abc import Iterable
-from typing import overload, Union, TypeVar
+from typing import overload, Union, TypeVar, Iterable
 
 T = TypeVar('T')
 S = TypeVar('S')  # <1>


### PR DESCRIPTION
the code incorrectly imports collections.Iterable, instead of typing.Iterable.

This error is not caught for python 3.9+ because of interpreter changes

But for python 3.8, the code throws error -
```
$ python mysum.py 
Traceback (most recent call last):
  File "mysum.py", line 10, in <module>
    def sum(it: Iterable[T]) -> Union[T, int]: ...  # <2>
```